### PR TITLE
feat: Add message editing functionality

### DIFF
--- a/src/components/chat/MessageItem.css
+++ b/src/components/chat/MessageItem.css
@@ -68,6 +68,19 @@
   opacity: 1 !important;
 }
 
+.edit-mode {
+  width: 100%;
+  min-width: 600px;
+}
+
+.edit-mode textarea {
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
 .message-item.user {
   justify-content: flex-end;
 }

--- a/src/components/chat/MessageItem.css
+++ b/src/components/chat/MessageItem.css
@@ -37,6 +37,37 @@
   opacity: 1 !important;
 }
 
+.edit-icon-svg {
+  fill: none !important;
+  stroke: #888 !important;
+  stroke-width: 2 !important;
+  color: #888 !important;
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  width: 16px !important;
+  height: 16px !important;
+  min-width: 16px !important;
+  min-height: 16px !important;
+  max-width: 16px !important;
+  max-height: 16px !important;
+  flex-shrink: 0 !important;
+  transition: stroke 0.2s ease !important;
+}
+
+.edit-icon-svg:hover {
+  stroke: #4444ff !important;
+}
+
+.edit-icon-svg * {
+  fill: none !important;
+  stroke: inherit !important;
+  stroke-width: inherit !important;
+  color: inherit !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
 .message-item.user {
   justify-content: flex-end;
 }

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -36,6 +36,16 @@ const MessageItem = ({ message, formattingSettings, onDelete, onEdit }: MessageI
     setEditContent(message.content);
   };
 
+  // Calculate textarea height based on content
+  const calculateTextareaHeight = () => {
+    const lineHeight = 1.5;
+    const fontSize = 16; // 1rem = 16px typically
+    const padding = 32; // 1rem top + 1rem bottom = 32px
+    const lines = editContent.split('\n').length;
+    const minLines = Math.max(3, lines); // At least 3 lines, or more if content is longer
+    return Math.max(100, minLines * fontSize * lineHeight + padding);
+  };
+
   const handleCancelEdit = () => {
     setIsEditing(false);
     setEditContent(message.content);
@@ -179,14 +189,19 @@ const MessageItem = ({ message, formattingSettings, onDelete, onEdit }: MessageI
                 disabled={isLoading}
                 style={{
                   width: '100%',
-                  minHeight: '80px',
-                  padding: '8px',
+                  height: `${calculateTextareaHeight()}px`,
+                  minHeight: '100px',
+                  minWidth: '600px',
+                  padding: '1rem 1.25rem',
                   border: '1px solid #ccc',
-                  borderRadius: '4px',
-                  resize: 'vertical',
+                  borderRadius: '1rem',
+                  resize: 'both',
                   fontFamily: 'inherit',
                   fontSize: 'inherit',
-                  lineHeight: 'inherit'
+                  lineHeight: '1.5',
+                  backgroundColor: '#3a3a3a',
+                  color: '#fff',
+                  boxSizing: 'border-box'
                 }}
               />
               <div 

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -106,7 +106,10 @@ const MessageItem = ({ message, formattingSettings, onDelete, onEdit }: MessageI
                   e.currentTarget.style.color = '#888';
                 }}
               >
-                <MdEdit size={16} />
+                <MdEdit 
+                  size={16} 
+                  className="edit-icon-svg"
+                />
               </button>
             )}
             

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { MdDeleteOutline } from 'react-icons/md';
+import { MdDeleteOutline, MdEdit } from 'react-icons/md';
 import type { Message, FormattingSettings } from '../../types';
 import FormattedText from '../common/FormattedText';
 import './MessageItem.css';
@@ -8,11 +8,15 @@ interface MessageItemProps {
   message: Message;
   formattingSettings?: FormattingSettings | null;
   onDelete?: (messageId: number) => void;
+  onEdit?: (messageId: number, newContent: string) => Promise<void>;
 }
 
-const MessageItem = ({ message, formattingSettings, onDelete }: MessageItemProps) => {
+const MessageItem = ({ message, formattingSettings, onDelete, onEdit }: MessageItemProps) => {
   const [isHovered, setIsHovered] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(message.content);
+  const [isLoading, setIsLoading] = useState(false);
 
   const formatTime = (timestamp: string) => {
     const date = new Date(timestamp);
@@ -27,6 +31,30 @@ const MessageItem = ({ message, formattingSettings, onDelete }: MessageItemProps
     }
   };
 
+  const handleEdit = () => {
+    setIsEditing(true);
+    setEditContent(message.content);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditContent(message.content);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!onEdit || editContent.trim() === '') return;
+    
+    setIsLoading(true);
+    try {
+      await onEdit(message.id, editContent.trim());
+      setIsEditing(false);
+    } catch (error) {
+      console.error('Error updating message:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <div 
       className={`message-item ${message.role}`}
@@ -37,7 +65,7 @@ const MessageItem = ({ message, formattingSettings, onDelete }: MessageItemProps
       }}
     >
       <div className="message-content">
-        {onDelete && (
+        {(onDelete || onEdit) && !isEditing && (
           <div 
             style={{
               position: 'absolute',
@@ -47,41 +75,76 @@ const MessageItem = ({ message, formattingSettings, onDelete }: MessageItemProps
               zIndex: 999,
               opacity: isHovered ? 1 : 0,
               transition: 'opacity 0.2s ease',
-              pointerEvents: isHovered ? 'auto' : 'none'
+              pointerEvents: isHovered ? 'auto' : 'none',
+              display: 'flex',
+              gap: '4px'
             }}
           >
-            <button
-              onClick={handleDelete}
-              onMouseEnter={() => setShowTooltip(true)}
-              onMouseLeave={() => setShowTooltip(false)}
-              aria-label="Delete this message and all subsequent messages"
-              style={{
-                background: 'transparent',
-                border: 'none',
-                borderRadius: '4px',
-                width: '28px',
-                height: '28px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer',
-                color: '#888',
-                transition: 'all 0.2s ease'
-              }}
-              onMouseOver={(e) => {
-                e.currentTarget.style.background = 'rgba(0, 0, 0, 0.1)';
-                e.currentTarget.style.color = '#ff4444';
-              }}
-              onMouseOut={(e) => {
-                e.currentTarget.style.background = 'transparent';
-                e.currentTarget.style.color = '#888';
-              }}
-            >
-              <MdDeleteOutline 
-                size={16} 
-                className="delete-icon-svg"
-              />
-            </button>
+            {onEdit && (
+              <button
+                onClick={handleEdit}
+                aria-label="Edit this message"
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  borderRadius: '4px',
+                  width: '28px',
+                  height: '28px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  color: '#888',
+                  transition: 'all 0.2s ease'
+                }}
+                onMouseOver={(e) => {
+                  e.currentTarget.style.background = 'rgba(0, 0, 0, 0.1)';
+                  e.currentTarget.style.color = '#4444ff';
+                }}
+                onMouseOut={(e) => {
+                  e.currentTarget.style.background = 'transparent';
+                  e.currentTarget.style.color = '#888';
+                }}
+              >
+                <MdEdit size={16} />
+              </button>
+            )}
+            
+            {onDelete && (
+              <button
+                onClick={handleDelete}
+                onMouseEnter={() => setShowTooltip(true)}
+                onMouseLeave={() => setShowTooltip(false)}
+                aria-label="Delete this message and all subsequent messages"
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  borderRadius: '4px',
+                  width: '28px',
+                  height: '28px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  color: '#888',
+                  transition: 'all 0.2s ease'
+                }}
+                onMouseOver={(e) => {
+                  e.currentTarget.style.background = 'rgba(0, 0, 0, 0.1)';
+                  e.currentTarget.style.color = '#ff4444';
+                }}
+                onMouseOut={(e) => {
+                  e.currentTarget.style.background = 'transparent';
+                  e.currentTarget.style.color = '#888';
+                }}
+              >
+                <MdDeleteOutline 
+                  size={16} 
+                  className="delete-icon-svg"
+                />
+              </button>
+            )}
+            
             {showTooltip && (
               <div 
                 style={{
@@ -105,10 +168,69 @@ const MessageItem = ({ message, formattingSettings, onDelete }: MessageItemProps
           </div>
         )}
         <div className="message-text">
-          <FormattedText 
-            text={message.content} 
-            formattingSettings={formattingSettings}
-          />
+          {isEditing ? (
+            <div className="edit-mode">
+              <textarea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                disabled={isLoading}
+                style={{
+                  width: '100%',
+                  minHeight: '80px',
+                  padding: '8px',
+                  border: '1px solid #ccc',
+                  borderRadius: '4px',
+                  resize: 'vertical',
+                  fontFamily: 'inherit',
+                  fontSize: 'inherit',
+                  lineHeight: 'inherit'
+                }}
+              />
+              <div 
+                style={{
+                  display: 'flex',
+                  gap: '8px',
+                  marginTop: '8px',
+                  justifyContent: 'flex-end'
+                }}
+              >
+                <button
+                  onClick={handleCancelEdit}
+                  disabled={isLoading}
+                  style={{
+                    padding: '6px 12px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                    background: 'transparent',
+                    cursor: 'pointer',
+                    fontSize: '0.9rem'
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSaveEdit}
+                  disabled={isLoading || editContent.trim() === ''}
+                  style={{
+                    padding: '6px 12px',
+                    border: 'none',
+                    borderRadius: '4px',
+                    background: editContent.trim() === '' ? '#ccc' : '#007bff',
+                    color: 'white',
+                    cursor: editContent.trim() === '' ? 'not-allowed' : 'pointer',
+                    fontSize: '0.9rem'
+                  }}
+                >
+                  {isLoading ? 'Saving...' : 'Save'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <FormattedText 
+              text={message.content} 
+              formattingSettings={formattingSettings}
+            />
+          )}
         </div>
         <div className="message-timestamp">
           {formatTime(message.timestamp)}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -10,9 +10,10 @@ interface MessageListProps {
   isStreaming: boolean;
   formattingSettings?: FormattingSettings | null;
   onDeleteMessage?: (messageId: number) => void;
+  onEditMessage?: (messageId: number, newContent: string) => Promise<void>;
 }
 
-const MessageList = ({ messages, streamingMessage, isStreaming, formattingSettings, onDeleteMessage }: MessageListProps) => {
+const MessageList = ({ messages, streamingMessage, isStreaming, formattingSettings, onDeleteMessage, onEditMessage }: MessageListProps) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = () => {
@@ -39,6 +40,7 @@ const MessageList = ({ messages, streamingMessage, isStreaming, formattingSettin
             message={message} 
             formattingSettings={formattingSettings}
             onDelete={onDeleteMessage}
+            onEdit={onEditMessage}
           />
         ))}
 

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -191,6 +191,23 @@ const ChatPage = () => {
     }
   };
 
+  const handleEditMessage = async (messageId: number, newContent: string) => {
+    try {
+      const updatedMessage = await chatApi.updateMessage(messageId, newContent);
+      
+      // Update the message in the local state
+      setMessages(prev => prev.map(msg => 
+        msg.id === messageId 
+          ? { ...msg, content: newContent }
+          : msg
+      ));
+    } catch (err) {
+      console.error('Error updating message:', err);
+      setError('Failed to update message. Please try again.');
+      throw err; // Re-throw to let MessageItem handle the error state
+    }
+  };
+
   const handleDeleteMessage = async (messageId: number) => {
     if (!chatSessionId) return;
 
@@ -308,6 +325,7 @@ const ChatPage = () => {
             isStreaming={isStreaming}
             formattingSettings={formattingSettings}
             onDeleteMessage={handleDeleteMessage}
+            onEditMessage={handleEditMessage}
           />
         </div>
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -325,6 +325,11 @@ export const chatApi = {
     await api.delete(`/api/v1/messages/${messageId}`);
   },
 
+  updateMessage: async (messageId: number, content: string): Promise<Message> => {
+    const response = await api.put(`/api/v1/messages/${messageId}`, { content });
+    return response.data.data || response.data;
+  },
+
   deleteChatSession: async (chatSessionId: number): Promise<void> => {
     await api.delete(`/api/v1/chat-sessions/${chatSessionId}`);
   },


### PR DESCRIPTION
## Overview
This PR adds the ability to edit messages in chat conversations. Users can now modify their own messages and AI responses inline.

## Features Added
- ✅ **Edit button**: Appears on hover next to the delete button
- ✅ **Edit mode**: Click edit to switch message to editable textarea
- ✅ **Raw content editing**: Shows unformatted text for precise editing
- ✅ **Save/Cancel buttons**: Clear actions to commit or discard changes
- ✅ **Dynamic textarea sizing**: Automatically sizes to show all content
- ✅ **API integration**: Updates messages via `PUT /api/v1/messages/{messageId}`
- ✅ **Error handling**: Proper feedback for failed operations
- ✅ **Loading states**: Visual feedback during save operations

## Implementation Details

### API Changes
- Added `updateMessage` function to `src/services/api.ts`
- Calls `PUT /api/v1/messages/{messageId}` endpoint

### UI Components
- **MessageItem**: Added edit state management and edit mode UI
- **MessageList**: Pass-through for edit functionality 
- **ChatPage**: Handles message updates and state management

### Key Features
- **Icon visibility**: Added CSS styling for edit icon (similar to delete icon solution)
- **Textarea sizing**: 600px minimum width, dynamic height based on content
- **Edit mode styling**: Matches original message appearance with dark theme
- **Both resize directions**: Users can resize textarea horizontally and vertically

## Files Changed
- `src/components/chat/MessageItem.tsx` - Main edit functionality
- `src/components/chat/MessageItem.css` - Icon styling and edit mode layout
- `src/components/chat/MessageList.tsx` - Props pass-through
- `src/pages/ChatPage.tsx` - Edit handler and state management
- `src/services/api.ts` - API integration

## Testing
- ✅ Edit button appears on message hover
- ✅ Edit mode shows textarea with current content
- ✅ Save updates message and returns to display mode
- ✅ Cancel discards changes without API call
- ✅ Changes persist after page reload (with backend fix)
- ✅ Error handling works for failed API calls

## Related Issues
- Addresses GitHub issue #2 (icon visibility technical debt - temporary workaround applied)

## Dependencies
- Requires backend `PUT /api/v1/messages/{messageId}` endpoint (✅ working)
- Uses existing React Icons (`MdEdit`) and styling patterns